### PR TITLE
Fix: onVimModeChange

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -112,8 +112,8 @@ export default class VimIMSwitchPlugin extends Plugin {
 	onVimModeChange = async (cm: any) => {
 		// this.debug_log("Vim Input Method Switch: Vim mode change to : " + cm.mode);
 
+		await this.getFcitxRemoteStatus();
 		if (cm.mode == "normal" || cm.mode == "visual") {
-			await this.getFcitxRemoteStatus();
 			if (this.imStatus == IMStatus.Active) {
 				await this.deactivateIM();
 			}


### PR DESCRIPTION
- Call getFcitxRemoteStatus when Vim mode change to update imStatus
- Try to fix that the input method does not change when entering insert mode for the second time

对于这个问题https://github.com/yuanotes/obsidian-vim-im-switch-plugin/issues/25#issuecomment-1873143593
认为应该是函数`onVimModeChange`, 在进入insert时, 只修改输入法, 未通过函数`getFcitxRemoteStatus `更新`imStatus`导致.
本修复仅将对`getFcitxRemoteStatus`的调用提升到进入`onVimModeChange`时, 从而使得每次改变模式时均更新`imStatus`.